### PR TITLE
chore: update hugo to 0.156.0

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.156.0
     steps:
       - name: Install Hugo CLI
         run: |
@@ -54,7 +54,7 @@ jobs:
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           HUGO_ENVIRONMENT: production
-          TZ: America/Los_Angeles
+          TZ: Europe/Copenhagen
         run: |
           hugo \
             --gc \

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ go.work
 
 public/*
 resources/_gen/
+
+# Code assistants
+.claude/
+AGENTS.md
+CLAUDE.md
+.github/copilot-instructions.md

--- a/layouts/shortcodes/contact_list.html
+++ b/layouts/shortcodes/contact_list.html
@@ -1,3 +1,0 @@
-{{ range .Site.Params.contacts }}
-<p><i class="{{ .icon }}"></i>&nbsp;<a href="{{ .url | safeURL }}">{{ .value }}</a></p>
-{{ end }}

--- a/layouts/shortcodes/contact_list.html
+++ b/layouts/shortcodes/contact_list.html
@@ -1,0 +1,3 @@
+{{ range .Site.Params.contacts }}
+<p><i class="{{ .icon }}"></i>&nbsp;<a href="{{ .url | safeURL }}">{{ .value }}</a></p>
+{{ end }}


### PR DESCRIPTION
Updates `hugo` to `0.156.0`.  This required an update to the `hugo-scroll` theme to fix deprecation of `ToCSS` helper.